### PR TITLE
Remove removed function attribute from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ groups = keycloak_admin.get_groups()
 group = keycloak_admin.get_group(group_id='group_id')
 
 # Get group by name
-group = keycloak_admin.get_group_by_path(path='/group/subgroup', search_in_subgroups=True)
+group = keycloak_admin.get_group_by_path(path='/group/subgroup')
 
 # Function to trigger user sync from provider
 sync_users(storage_id="storage_di", action="action")


### PR DESCRIPTION
Remove option search_in_subgroups from get_group_by_path usage example on README. This option was removed on b3dd7d49046ff99d2af152d5a3bba1eb64eb92b7